### PR TITLE
Mise à jour de l'URL pour blockly

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Sur iPad, similaire à Scratch, en plus simple. Il faut savoir lire l'anglais. h
 Application Microsoft permettant de s'initier à la programmation de jeux simples sur mobile (iPad, iPhone, Android, PC, Mac, Windows Phone) : https://www.touchdevelop.com/
 
 ### Blockly
-Même principe que les autres. Utilisation plutôt en ligne, même si on peut télécharger et installer sur sa propre machine. Traduit en français. https://code.google.com/p/blockly/
+Même principe que les autres. Utilisation plutôt en ligne, même si on peut télécharger et installer sur sa propre machine. Traduit en français. https://developers.google.com/blockly/
 
 ### Kodu
 Environnement graphique de programmation de jeux pour Windows et XBox. A partir de 10 ans. http://www.kodugamelab.com/


### PR DESCRIPTION
L'adresse mentionnée pour blockly affiche désormais "Blockly has moved", la nouvelle adresse est sur "developers.google.com" au lieu de "code.google.com".